### PR TITLE
updated composer.json for Contao 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
 	},
 	"require" : {
 		"php" : ">=5.3",
-		"contao/core" : ">=3.2,<4"
+		"contao/core-bundle":"~3.2 || ~4.2",
+		"contao-community-alliance/composer-plugin":"~2.4 || ~3.0"
 	},
 	"replace" : {
 		"backboneit/contao-opengraph" : "self.version",


### PR DESCRIPTION
This extension is reportedly compatible with Contao 4 (see [here](https://community.contao.org/de/showthread.php?66392-conto-sharebuttons-und-contao-opengraph-f%C3%BCr-Contao-4&p=437604&viewfull=1#post437604) for instance).

However, the current requirements in the `composer.json` do not allow it to be installed in Contao 4 via Composer. This PR changes that.